### PR TITLE
Add per-feature color support to custom layers

### DIFF
--- a/js/map-creator.js
+++ b/js/map-creator.js
@@ -912,18 +912,20 @@ export class MapCreator {
     generateMapboxStyle(geometryType, fillColor, strokeColor, strokeWidth) {
         const style = {};
 
+        // Use per-feature fill-color / stroke-color when present,
+        // falling back to the user-selected colors from the UI.
         if (geometryType === 'Polygon') {
-            style['fill-color'] = fillColor;
+            style['fill-color'] = ['coalesce', ['get', 'fill-color'], ['get', 'color'], fillColor];
             style['fill-opacity'] = 0.6;
-            style['line-color'] = strokeColor;
+            style['line-color'] = ['coalesce', ['get', 'stroke-color'], ['get', 'color'], strokeColor];
             style['line-width'] = parseFloat(strokeWidth);
         } else if (geometryType === 'LineString') {
-            style['line-color'] = strokeColor;
+            style['line-color'] = ['coalesce', ['get', 'stroke-color'], ['get', 'color'], strokeColor];
             style['line-width'] = parseFloat(strokeWidth);
         } else if (geometryType === 'Point') {
-            style['circle-color'] = fillColor;
+            style['circle-color'] = ['coalesce', ['get', 'fill-color'], ['get', 'color'], fillColor];
             style['circle-radius'] = parseFloat(strokeWidth) * 2;
-            style['circle-stroke-color'] = strokeColor;
+            style['circle-stroke-color'] = ['coalesce', ['get', 'stroke-color'], ['get', 'color'], strokeColor];
             style['circle-stroke-width'] = 2;
         }
 


### PR DESCRIPTION
## Overview
This change enables custom GeoJSON/CSV layers to use color properties from individual features, allowing each feature to have its own color while maintaining backward compatibility with the existing color picker UI.

## Key Changes
- **Modified**: `js/map-creator.js` - Updated `generateMapboxStyle()` method to use Mapbox expressions for per-feature coloring

## Fallback Mechanism Details

The implementation uses Mapbox's `coalesce` expression to check feature properties in priority order, falling back to UI-selected colors when feature properties are missing:

### For Polygons:
- **Fill color**: `['coalesce', ['get', 'fill-color'], ['get', 'color'], <UI fill color>]`
  - First tries `properties.fill-color`
  - Then tries `properties.color`
  - Finally falls back to color picker fill value
- **Stroke color**: `['coalesce', ['get', 'stroke-color'], ['get', 'color'], <UI stroke color>]`
  - First tries `properties.stroke-color`
  - Then tries `properties.color`
  - Finally falls back to color picker stroke value

### For Lines:
- **Stroke color**: `['coalesce', ['get', 'stroke-color'], ['get', 'color'], <UI stroke color>]`
  - Same priority order as polygon strokes

### For Points:
- **Fill color**: `['coalesce', ['get', 'fill-color'], ['get', 'color'], <UI fill color>]`
  - Same priority order as polygon fills
- **Stroke color**: `['coalesce', ['get', 'stroke-color'], ['get', 'color'], <UI stroke color>]`
  - Same priority order as polygon strokes

## Usage Example

Features in your GeoJSON can now include color properties:

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "name": "Red Building",
        "fill-color": "#ff0000",
        "stroke-color": "#990000"
      },
      "geometry": { "type": "Point", "coordinates": [72.8, 18.9] }
    },
    {
      "type": "Feature",
      "properties": {
        "name": "Green Building",
        "color": "#00ff00"
      },
      "geometry": { "type": "Point", "coordinates": [72.9, 18.95] }
    },
    {
      "type": "Feature",
      "properties": {
        "name": "Default Building"
      },
      "geometry": { "type": "Point", "coordinates": [73.0, 19.0] }
    }
  ]
}
```

The first feature uses `fill-color` and `stroke-color`, the second uses `color` (applied to both fill and stroke), and the third falls back to the UI color picker values.

## Backward Compatibility
- Existing layers without color properties work unchanged
- Color picker UI remains functional as the final fallback
- No breaking changes to existing functionality

## Benefits
- **Flexibility**: Each feature can have unique colors
- **Data-driven styling**: Colors can come directly from your data source
- **Progressive enhancement**: Works with or without color properties
- **Mapbox-native**: Uses efficient Mapbox expressions for performance

## Testing
The change affects custom layers created through the "add your own data" UI flow. Existing pre-configured atlas layers are unaffected. Test by:

1. Adding GeoJSON with color properties via URL/upload
2. Verifying features render with their individual colors
3. Confirming fallback to color picker when properties are missing
4. Ensuring existing layers still work without color properties