### PR TITLE
Add GA4 event tagging across the atlas

### DIFF
--- a/bus/index.html
+++ b/bus/index.html
@@ -347,6 +347,7 @@
             background: rgba(34, 197, 94, 0.5);
         }
     </style>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 
 <body class="bg-sim-dark text-green-400">

--- a/docs/analytics-plan.md
+++ b/docs/analytics-plan.md
@@ -1,0 +1,56 @@
+# amche-atlas Analytics Plan (GA4)
+
+Goal: understand which features and data layers users actually use, so iteration effort goes where it matters. Property: `G-FBVGZ4HJV0` (already live on index.html, pageviews only today).
+
+## Current state
+
+- GA4 base tag loads only on `index.html`, and only when `hostname === amche.in` (`js/index.js`). The other 12 entry points (bus, game, timelapse, warper, map-*, pages/*) send nothing.
+- Zero custom events — no visibility into layer usage, search, share, or export.
+- `sound/` has its own Firebase measurement ID (`G-VPDTDN640G`); left untouched.
+
+## Architecture
+
+One new module, `js/analytics.js`:
+
+- `initAnalytics()` — injects the gtag loader (prod hostname only). Replaces the inline copy in `js/index.js`. Included by every HTML entry point so all sub-apps report pageviews.
+- `trackEvent(name, params)` — safe wrapper: no-ops if gtag absent, console-logs events on localhost so instrumentation is verifiable without GA access. All instrumentation goes through this; never call `gtag()` directly.
+
+## Event taxonomy (phase 1: main map)
+
+| Event | Params | Trigger | Source file |
+|---|---|---|---|
+| `layer_toggle` | `layer_id`, `visible` | User toggles a layer group (NOT initial page load) | `map-layer-controls.js` |
+| `search_select` | `search_type` (place/cadastral), `result_name` | User picks a search result | `map-search-control.js` |
+| `feature_inspect` | `layer_id` | Feature popup opened via map click | `map-feature-state-manager.js` |
+| `share_action` | `method` | Share/copy-link button used | share control |
+| `map_export` | `export_type` (geojson/style/image/pdf) | Export executed | `map-export-control.js` |
+| `geolocate` | `status` (success/error) | Geolocation resolves | `button-geolocation-manager.js` |
+| `measure_use` | — | Measure tool activated | `map-measure-control.js` |
+| `terrain_3d_toggle` | `enabled` | 3D terrain toggled | `terrain-3d-control.js` |
+| `atlas_load` | `atlas_id` | Map config loaded at init | `index.js` / `config-manager.js` |
+| `permalink_resolve` | `permalink_id` | Inbound `?p=` permalink redirect | `permalink-manager.js` |
+
+Conventions: snake_case names ≤40 chars, param values ≤100 chars, no PII — never send raw user queries, plot numbers, or coordinates; only names/ids of public layers and places.
+
+**Highest-value signal:** `layer_toggle` with `layer_id`. This alone answers "which of the curated layers do people actually use" — the core iteration question.
+
+## Phase 2 (later, separate PRs)
+
+- Sub-app events (bus route lookups, game plays, timelapse usage) once the pageview split shows where traffic is.
+- Arrival context: which URL-API params sessions land with (`url-api-params.js`).
+
+## GA4 console setup (manual, one-time)
+
+1. Admin → Custom definitions → create event-scoped custom dimensions: `layer_id`, `visible`, `search_type`, `export_type`, `method`, `status`, `atlas_id`, `permalink_id`, `result_name`, `enabled`. Without this, params are collected but invisible in standard reports.
+2. Wait ~24h after first events, then build a free-form Exploration: event name × layer_id.
+3. Optional: mark `share_action` and `map_export` as key events (proxies for "user got value").
+
+## Verification
+
+1. `npm start` → localhost: events print to console (gtag doesn't load off-prod, debug path does).
+2. Push to `dev` branch → amche.in/dev. Caveat: hostname there is still amche.in, so GA loads and dev traffic lands in prod data. analytics.js sends `debug_mode: true` when the path starts with `/dev`, so it appears in DebugView and can be filtered.
+3. GA4 DebugView while clicking through layers/search/export.
+
+## Privacy
+
+`privacy.html` updated to disclose GA4 and that interaction events contain feature/layer names, not personal data. Civic-tech audience: keep this honest and specific.

--- a/game/index.html
+++ b/game/index.html
@@ -168,6 +168,7 @@
             font-size: 1.25rem;
         }
     </style>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 
 <body>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,73 @@
+/**
+ * Analytics
+ *
+ * Single entry point for all Google Analytics (GA4) usage across amche pages.
+ * - initAnalytics() loads the gtag.js base tag (production hostname only)
+ * - trackEvent() safely records custom interaction events
+ *
+ * All instrumentation in the codebase must go through trackEvent();
+ * never call gtag() directly. See docs/analytics-plan.md for the
+ * event taxonomy and naming conventions.
+ */
+
+const MEASUREMENT_ID = (window.amche && window.amche.GOOGLE_ANALYTICS) || 'G-FBVGZ4HJV0';
+const PROD_HOSTNAME = (window.amche && window.amche.DOMAIN_URL) || 'amche.in';
+
+// Dev preview deploys to amche.in/dev on the same hostname, so tag those
+// hits with debug_mode to keep them identifiable in GA4 (DebugView + filters).
+const IS_DEBUG = window.location.pathname.startsWith('/dev');
+const IS_PROD = window.location.hostname === PROD_HOSTNAME;
+
+let initialized = false;
+
+/**
+ * Load the GA4 base tag. Safe to call multiple times; only loads once,
+ * and only on the production hostname. On localhost it does nothing —
+ * trackEvent() falls back to console logging so instrumentation can be
+ * verified without a GA property.
+ */
+export function initAnalytics() {
+    if (initialized || !IS_PROD) return;
+    initialized = true;
+
+    const gtagScript = document.createElement('script');
+    gtagScript.async = true;
+    gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID;
+    document.head.appendChild(gtagScript);
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
+
+    window.gtag('js', new Date());
+    window.gtag('config', MEASUREMENT_ID, IS_DEBUG ? { debug_mode: true } : {});
+}
+
+/**
+ * Record a custom event.
+ *
+ * @param {string} name  snake_case event name, <= 40 chars (GA4 limit)
+ * @param {Object} [params]  flat key/value pairs. Values are stringified
+ *   and truncated to 100 chars (GA4 param value limit). Never pass PII,
+ *   raw user queries, or coordinates.
+ */
+export function trackEvent(name, params = {}) {
+    const clean = {};
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
+        clean[key] = String(value).slice(0, 100);
+    }
+    if (IS_DEBUG) clean.debug_mode = true;
+
+    if (typeof window.gtag === 'function') {
+        window.gtag('event', name, clean);
+    } else if (!IS_PROD) {
+        // Local development: make instrumentation visible without GA
+        console.debug('[analytics]', name, clean);
+    }
+}
+
+// Convenience global so non-module scripts (sub-apps) can also report events
+window.amcheAnalytics = { initAnalytics, trackEvent };
+
+// Auto-init: pages only need to include this module to get pageview tracking
+initAnalytics();

--- a/js/button-geolocation-manager.js
+++ b/js/button-geolocation-manager.js
@@ -2,6 +2,8 @@
  * Geolocation Manager
  */
 
+import { trackEvent } from './analytics.js';
+
 export class ButtonGeolocationManager extends mapboxgl.GeolocateControl {
 
     constructor() {
@@ -80,6 +82,7 @@ export class ButtonGeolocationManager extends mapboxgl.GeolocateControl {
             // (code 1), which won't resolve itself.
             const isTransient = error.code === 2 || error.code === 3;
             if (!isTransient || this.locationErrorCount >= 3) {
+                trackEvent('geolocate', { status: 'error', error_code: error.code });
                 this._showErrorDialog(error);
             }
 
@@ -89,6 +92,11 @@ export class ButtonGeolocationManager extends mapboxgl.GeolocateControl {
         });
 
         this.on('geolocate', (e) => {
+            // geolocate fires continuously while tracking; report once per session
+            if (!this._analyticsGeolocateReported) {
+                this._analyticsGeolocateReported = true;
+                trackEvent('geolocate', { status: 'success' });
+            }
             this.locationErrorCount = 0;
             const now = performance.now();
             const elapsed = this._triggerStartedAt

--- a/js/index.js
+++ b/js/index.js
@@ -8,27 +8,10 @@ import { PermalinkManager } from './permalink-manager.js';
 import { IntroContentManager } from './intro-content-manager.js';
 import { initializeKeyboardController } from './keyboard-controller.js';
 import { SplashScreenManager } from './splash-screen-manager.js';
+import { initAnalytics, trackEvent } from './analytics.js';
 
 // Make IntroContentManager available globally for inline navigation menu
 window.IntroContentManager = IntroContentManager;
-
-function loadGoogleAnalytics() {
-    if (window.location.hostname === window.amche.DOMAIN_URL) {
-        // Load Google Analytics
-        const gtagScript = document.createElement('script');
-        gtagScript.async = true;
-        gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + window.amche.GOOGLE_ANALYTICS;
-        document.head.appendChild(gtagScript);
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-
-        gtag('js', new Date());
-        gtag('config', window.amche.GOOGLE_ANALYTICS);
-    }
-}
 
 const layerRegistry = new LayerRegistry();
 window.layerRegistry = layerRegistry;
@@ -42,7 +25,30 @@ $(window).on('load', async function () {
     const permalinkHandler = new PermalinkManager();
     permalinkHandler.detectAndRedirect();
 
-    loadGoogleAnalytics();
+    initAnalytics();
+
+    // Record which atlas configuration this session loaded
+    const atlasParam = new URLSearchParams(window.location.search).get('atlas');
+    trackEvent('atlas_load', {
+        atlas_id: atlasParam || 'default'
+    });
+
+    // Record inbound permalink resolution (stashed before the redirect
+    // by PermalinkManager, since the redirect would lose the event)
+    const resolvedPermalink = sessionStorage.getItem('amche_permalink_resolved');
+    if (resolvedPermalink) {
+        sessionStorage.removeItem('amche_permalink_resolved');
+        trackEvent('permalink_resolve', { permalink_id: resolvedPermalink });
+    }
+
+    // Layer visibility changes (user-initiated; map-layer-controls.js
+    // dispatches this only from the show/hide UI handlers, not initial load)
+    window.addEventListener('layer-toggled', (e) => {
+        trackEvent('layer_toggle', {
+            layer_id: e.detail?.layerId,
+            visible: e.detail?.visible
+        });
+    });
 
     initializeKeyboardController();
 

--- a/js/map-creator.js
+++ b/js/map-creator.js
@@ -252,6 +252,7 @@ export class MapCreator {
 
         $('#copy-inline-btn').on('click', () => {
             const url = $('#inline-url').val();
+            window.amcheAnalytics?.trackEvent('share_action', { method: 'copy_map_url' });
             navigator.clipboard.writeText(url).then(() => {
                 const $btn = $('#copy-inline-btn');
                 $btn.text('Copied!').removeClass('bg-blue-600 hover:bg-blue-700').addClass('bg-green-600');

--- a/js/map-export-control.js
+++ b/js/map-export-control.js
@@ -1,5 +1,6 @@
 import { ExportFrame } from './export-frame.js';
 import { InspectionHandlerLoader } from './inspection-handler-loader.js';
+import { trackEvent } from './analytics.js';
 
 export class MapExportControl {
     constructor() {
@@ -449,6 +450,8 @@ export class MapExportControl {
 
         try {
             const format = config.format;
+
+            trackEvent('map_export', { export_type: format });
 
             if (format === 'pdf') {
                 await this._exportPDF(config);

--- a/js/map-feature-state-manager.js
+++ b/js/map-feature-state-manager.js
@@ -4,6 +4,7 @@
  */
 import { MapboxAPI } from './mapbox-api.js';
 import { handlerLoader } from './inspection-handler-loader.js';
+import { trackEvent } from './analytics.js';
 
 export class MapFeatureStateManager extends EventTarget {
     constructor(map, mapboxAPI = null) {
@@ -452,6 +453,11 @@ export class MapFeatureStateManager extends EventTarget {
 
         // Process clicked features and select them
         const newSelections = [];
+
+        // Report which layer the topmost inspected feature belongs to
+        if (clickedFeatures[0]?.layerId) {
+            trackEvent('feature_inspect', { layer_id: clickedFeatures[0].layerId });
+        }
 
         clickedFeatures.forEach(({ feature, layerId, lngLat }) => {
             if (!feature || !layerId) return;

--- a/js/map-measure-control.js
+++ b/js/map-measure-control.js
@@ -5,6 +5,8 @@
  * Uses the globally loaded MapboxDraw (@mapbox/mapbox-gl-draw) and turf (@turf/turf).
  */
 
+import { trackEvent } from './analytics.js';
+
 const DRAW_LABELS_SOURCE_ID = 'source-draw-labels';
 const DRAW_LABELS_LAYER_ID = 'layer-draw-labels';
 const DRAW_NODES_SOURCE_ID = 'source-draw-nodes';
@@ -167,6 +169,7 @@ export class MeasureControl {
         this._toolsContainer.style.display = this._expanded ? 'block' : 'none';
         this._toggleBtn.classList.toggle('active', this._expanded);
         if (this._expanded) {
+            trackEvent('measure_use');
             // Reveal existing measurements and activate line measurement by default.
             this._setMeasurementsVisible(true);
             const lineMode = this._drawCtrl.modes.DRAW_LINE_STRING;

--- a/js/map-search-control.js
+++ b/js/map-search-control.js
@@ -1,4 +1,5 @@
 import { queryCadastralPlots, parseCadastralQuery, isCadastralSearchEnabled } from './cadastral-search.js'
+import { trackEvent } from './analytics.js'
 
 /**
  * MapSearchControl - Mapbox search with coordinate search and Goa cadastral
@@ -911,6 +912,13 @@ export class MapSearchControl {
             const coordinates = feature.geometry.coordinates;
 
             const isLocalSuggestion = feature.properties && feature.properties._isLocalSuggestion;
+
+            // Cadastral plot selections are deliberately not named in analytics:
+            // plot identifiers can reveal personal interest in specific parcels.
+            trackEvent('search_select', {
+                search_type: isLocalSuggestion ? 'cadastral' : 'place',
+                result_name: isLocalSuggestion ? undefined : feature.properties?.name
+            });
 
             if (isLocalSuggestion) {
                 // Set value silently (no input event) so Mapbox doesn't fetch suggestions

--- a/js/permalink-manager.js
+++ b/js/permalink-manager.js
@@ -29,6 +29,10 @@ export class PermalinkManager {
         const permalinkUrl = data.permalinks[permalinkId].url;
         const originalHash = window.location.hash;
 
+        // Stash for analytics: an event sent now would be lost in the redirect
+        // below, so index.js reports permalink_resolve after the page reloads.
+        try { sessionStorage.setItem('amche_permalink_resolved', permalinkId); } catch (e) { /* ignore */ }
+
         const extraParams = new URLSearchParams(urlParams);
         extraParams.delete('permalink');
         extraParams.delete('p');

--- a/js/terrain-3d-control.js
+++ b/js/terrain-3d-control.js
@@ -1,6 +1,8 @@
 /**
  * Controller for Three Dimensional Terrain
  */
+import { trackEvent } from './analytics.js';
+
 export class Terrain3DControl {
     constructor(options = {}) {
         this.options = {
@@ -716,6 +718,7 @@ export class Terrain3DControl {
 
         $checkbox.on('change', (e) => {
             this._enabled = e.target.checked;
+            trackEvent('terrain_3d_toggle', { enabled: this._enabled });
             // Show/hide terrain controls based on checkbox state
             $terrainControls.css('display', this._enabled ? 'block' : 'none');
             this._updateTerrain();

--- a/map-browser.html
+++ b/map-browser.html
@@ -1229,6 +1229,7 @@
             }
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body class="bg-gray-900">

--- a/map-creator.html
+++ b/map-creator.html
@@ -311,6 +311,7 @@
             animation: spin 1s linear infinite;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body class="bg-gray-900">

--- a/map-export-layout.html
+++ b/map-export-layout.html
@@ -291,6 +291,7 @@
             font-size: 0.9em;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 <body>
     <div class="pdf-page">

--- a/map-export.html
+++ b/map-export.html
@@ -544,6 +544,7 @@
             font-style: italic;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body>

--- a/map-information.html
+++ b/map-information.html
@@ -142,6 +142,7 @@
             font-size: 1rem;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body class="bg-slate-900 text-slate-100 flex flex-col">

--- a/map-inspector.html
+++ b/map-inspector.html
@@ -398,6 +398,7 @@
             border-bottom: 2px solid #3b82f6 !important;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body class="bg-gray-900 text-white" style="display: flex; flex-direction: column;">

--- a/offline.html
+++ b/offline.html
@@ -51,6 +51,7 @@
             margin-bottom: 24px;
         }
     </style>
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 <body>
     <div class="container">

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -7,6 +7,7 @@
     <title>Amche Contact Sheet</title>
     <!-- Tailwind CSS via CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 
 <body class="flex flex-col">

--- a/pages/mhedei.html
+++ b/pages/mhedei.html
@@ -7,6 +7,7 @@
     <title>The Mhadei Indexed-database</title>
     <!-- Tailwind CSS via CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 
 <body class="flex flex-col">

--- a/privacy.html
+++ b/privacy.html
@@ -31,6 +31,7 @@
         src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.19.1/cdn/shoelace.js"></script>
     <link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'"
         href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.19.1/cdn/themes/light.css">
+    <script defer type="module" src="js/analytics.js"></script>
 </head>
 
 <body class="flex flex-col min-h-screen">
@@ -146,7 +147,14 @@
                             <li>How long you spend on the website</li>
                             <li>What type of device and browser you use</li>
                             <li>Your general location (city or country level, not exact address)</li>
+                            <li>Which map features you interact with — for example which map layers you turn on or
+                                off, use of search, measurement, 3D terrain and export tools</li>
                         </ul>
+                        <p class="text-gray-700 leading-relaxed mt-3">
+                            These interaction events record only the names of public map layers and tools — never
+                            your search text, cadastral plot numbers, GPS coordinates, or anything that could
+                            identify you or a property you looked up.
+                        </p>
                         <p class="text-gray-700 leading-relaxed mt-3">
                             This data helps us understand how to make the website better for local users. We do not
                             collect personally

--- a/timelapse/index.html
+++ b/timelapse/index.html
@@ -285,6 +285,7 @@
     text-align: right;
   }
 </style>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 <body>
 

--- a/warper/index.html
+++ b/warper/index.html
@@ -361,6 +361,7 @@
             transform: translate(-50%, 50%) rotate(45deg);
         }
     </style>
+    <script defer type="module" src="../js/analytics.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION

<!-- 
Breifly describe the changes you made with any ticket references 
-->

## Summary
- New js/analytics.js: single gtag entry point with safe trackEvent() wrapper (console-logs on localhost, debug_mode on /dev paths)
- GA4 base tag now on all 14 HTML entry points (was index.html only)
- Custom events: layer_toggle, search_select, feature_inspect, map_export, geolocate, measure_use, terrain_3d_toggle, atlas_load, permalink_resolve, share_action
- Privacy policy updated to disclose interaction events; cadastral search selections are recorded by type only, never plot identifiers
- docs/analytics-plan.md: taxonomy, GA4 console setup, verification

## Testing Strategy
Will review on GA once code is running 

Live preview: https://amche.in/dev/ 

<!-- 

# On amche-atlas

Use `git push origin HEAD:dev --force` to update deploy to /dev site for user testing

# On your fork

```
git remote set-url amche git@github.com:publicmap/amche-atlas.git
git push amche HEAD:dev --force
```
-->
