### PR TITLE
Fix cadastral village center for duplicate village names across talukas

### DIFF
--- a/docs/CADASTRAL-SEARCH.md
+++ b/docs/CADASTRAL-SEARCH.md
@@ -126,6 +126,8 @@ git tag v1.x.x && git push origin main --tags
 
 **Parquet read:** for each candidate village, row groups are selected using Parquet `village` column min/max statistics, then rows are filtered and ranked in JS. Up to 200 candidates are scored; exact survey match ranks highest, shorter survey numbers beat longer prefix matches (`1` beats `101`), exact subdiv beats subdiv prefix (`1/1` beats `1/11`). At most 5 results are returned.
 
+When a village is selected from the plot search dropdown (village + taluka), plot and survey queries are scoped to that taluka so duplicate village names across talukas do not cross-match. Village fly-to uses the mean of valid plot centroids for that village/taluka pair.
+
 Duplicate village names across talukas (e.g. Verlem in Sanguem and Quepem) appear as separate suggestions distinguished by taluka in the label.
 
 ## Deployment notes

--- a/js/cadastral-search-ui.js
+++ b/js/cadastral-search-ui.js
@@ -107,7 +107,7 @@ export class CadastralSearchUI {
             this.userPickedVillage = true
             this.selectedVillage = parseVillageEntryKey(this.villageSelect.value)
             sessionStorage.setItem('cadastral-village', this.villageSelect.value)
-            this._flyToVillage(this.selectedVillage?.village)
+            this._flyToVillage(this.selectedVillage)
             this._runSearch()
         })
 
@@ -247,9 +247,9 @@ export class CadastralSearchUI {
         this.villageSelect.value = villageEntryKey(entry)
     }
 
-    _flyToVillage(villageName) {
-        if (!villageName) return
-        getVillageCenter(villageName).then(center => {
+    _flyToVillage(villageEntry) {
+        if (!villageEntry?.village) return
+        getVillageCenter(villageEntry.village, villageEntry.taluka).then(center => {
             if (!center) return
             this.map.flyTo({ center: [center.lon, center.lat], zoom: 14 })
         }).catch(() => {})
@@ -267,7 +267,7 @@ export class CadastralSearchUI {
         }
 
         this._pendingSurvey = surveyRaw
-        queryCadastralPlotsByVillage(this.selectedVillage.village, surveyRaw)
+        queryCadastralPlotsByVillage(this.selectedVillage.village, this.selectedVillage.taluka, surveyRaw)
             .then(features => {
                 if (this._pendingSurvey !== surveyRaw) return
                 this._renderResults(features)

--- a/js/cadastral-search.js
+++ b/js/cadastral-search.js
@@ -111,6 +111,23 @@ export function formatCadastralLabel({ village, taluka, survey, subdiv }) {
     return `${village} — ${surveyPart} — ${taluka}`
 }
 
+export function formatSurveyLabel({ survey, subdiv }) {
+    return subdiv ? `${survey}/${subdiv}` : String(survey ?? '')
+}
+
+function labelToSurveyRow(label) {
+    const slashIdx = label.indexOf('/')
+    if (slashIdx === -1) return { survey: label, subdiv: '' }
+    return { survey: label.slice(0, slashIdx), subdiv: label.slice(slashIdx + 1) }
+}
+
+export function sortSurveyOptionLabels(a, b) {
+    return sortSurveyMatches(
+        { row: labelToSurveyRow(a), score: 0 },
+        { row: labelToSurveyRow(b), score: 0 },
+    )
+}
+
 export function normalizeSurveySegment(str) {
     return String(str ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase()
 }
@@ -333,6 +350,40 @@ export async function queryCadastralPlotsByVillage(villageName, taluka, surveyRa
     const matches = await collectMatchesForVillage(villageName, taluka, parsed)
     matches.sort(sortSurveyMatches)
     return matches.slice(0, limit).map(({ row }) => rowToFeature(row))
+}
+
+export async function listSurveyOptionsForVillage(villageName, taluka, filterRaw = '', limit = 100) {
+    if (!isCadastralSearchEnabled() || !villageName) return []
+    await lazyInit()
+
+    const parsed = parseSurveyQuery(filterRaw)
+    if (!parsed.surveyPrefix) return []
+
+    const seen = new Set()
+    const labels = []
+    const ranges = getMatchingRowGroupRanges(villageName)
+
+    for (const range of ranges) {
+        const rows = await parquetReadObjects({
+            file: parquetFile,
+            compressors,
+            columns: ['village', 'taluka', 'survey', 'subdiv'],
+            rowStart: range.start,
+            rowEnd: range.end,
+        })
+
+        for (const row of rows) {
+            if (!matchesVillageTaluka(row, villageName, taluka)) continue
+            if (scoreSurveyMatch(row, parsed) === null) continue
+            const label = formatSurveyLabel(row)
+            if (!label || seen.has(label)) continue
+            seen.add(label)
+            labels.push(label)
+        }
+    }
+
+    labels.sort(sortSurveyOptionLabels)
+    return labels.slice(0, limit)
 }
 
 export async function queryCadastralPlots(villagePart, surveyRaw, limit = 5) {

--- a/js/cadastral-search.js
+++ b/js/cadastral-search.js
@@ -185,9 +185,19 @@ function rowToFeature(r) {
     }
 }
 
-async function collectMatchesForVillage(villageName, parsed) {
+function matchesVillageTaluka(row, villageName, taluka) {
+    if (row.village.toLowerCase() !== villageName.toLowerCase()) return false
+    if (taluka && row.taluka.toLowerCase() !== taluka.toLowerCase()) return false
+    return true
+}
+
+export function isValidPlotCoord(lon, lat) {
+    return Number.isFinite(lon) && Number.isFinite(lat)
+        && lon > 73.5 && lon < 74.5 && lat > 14.8 && lat < 15.9
+}
+
+async function collectMatchesForVillage(villageName, taluka, parsed) {
     const matches = []
-    const candidateLower = villageName.toLowerCase()
     const ranges = getMatchingRowGroupRanges(villageName)
 
     for (const range of ranges) {
@@ -200,7 +210,8 @@ async function collectMatchesForVillage(villageName, parsed) {
         })
 
         for (const row of rows) {
-            if (row.village.toLowerCase() !== candidateLower) continue
+            if (!matchesVillageTaluka(row, villageName, taluka)) continue
+            if (!isValidPlotCoord(row.lon, row.lat)) continue
             const score = scoreSurveyMatch(row, parsed)
             if (score === null) continue
             matches.push({ row, score })
@@ -281,36 +292,45 @@ export function detectVillageFromMapCenter(map) {
     return findVillageEntry(name, taluka)
 }
 
-export async function getVillageCenter(villageName) {
+export async function getVillageCenter(villageName, taluka) {
     if (!isCadastralSearchEnabled() || !villageName) return null
     await lazyInit()
 
     const ranges = getMatchingRowGroupRanges(villageName)
-    const candidateLower = villageName.toLowerCase()
+    let lonSum = 0
+    let latSum = 0
+    let count = 0
 
     for (const range of ranges) {
         const rows = await parquetReadObjects({
             file: parquetFile,
             compressors,
-            columns: ['village', 'lon', 'lat'],
+            columns: ['village', 'taluka', 'lon', 'lat'],
             rowStart: range.start,
             rowEnd: range.end,
         })
-        const match = rows.find(r => r.village.toLowerCase() === candidateLower)
-        if (match) return { lon: match.lon, lat: match.lat }
+
+        for (const row of rows) {
+            if (!matchesVillageTaluka(row, villageName, taluka)) continue
+            if (!isValidPlotCoord(row.lon, row.lat)) continue
+            lonSum += row.lon
+            latSum += row.lat
+            count += 1
+        }
     }
 
-    return null
+    if (!count) return null
+    return { lon: lonSum / count, lat: latSum / count }
 }
 
-export async function queryCadastralPlotsByVillage(villageName, surveyRaw, limit = 5) {
+export async function queryCadastralPlotsByVillage(villageName, taluka, surveyRaw, limit = 5) {
     if (!isCadastralSearchEnabled() || !villageName) return []
     await lazyInit()
 
     const parsed = parseSurveyQuery(surveyRaw)
     if (!parsed.surveyPrefix) return []
 
-    const matches = await collectMatchesForVillage(villageName, parsed)
+    const matches = await collectMatchesForVillage(villageName, taluka, parsed)
     matches.sort(sortSurveyMatches)
     return matches.slice(0, limit).map(({ row }) => rowToFeature(row))
 }
@@ -326,7 +346,7 @@ export async function queryCadastralPlots(villagePart, surveyRaw, limit = 5) {
     const matches = []
 
     for (const candidate of candidates) {
-        const villageMatches = await collectMatchesForVillage(candidate.village, parsed)
+        const villageMatches = await collectMatchesForVillage(candidate.village, candidate.taluka, parsed)
         matches.push(...villageMatches)
     }
 

--- a/js/tests/cadastral-search.test.js
+++ b/js/tests/cadastral-search.test.js
@@ -6,6 +6,8 @@ import {
     villageEntryKey,
     parseVillageEntryKey,
     isValidPlotCoord,
+    formatSurveyLabel,
+    sortSurveyOptionLabels,
 } from '../cadastral-search.js'
 
 describe('parseSurveyQuery', () => {
@@ -108,5 +110,19 @@ describe('isValidPlotCoord', () => {
         expect(isValidPlotCoord(73.964, null)).toBe(false)
         expect(isValidPlotCoord(145.21, -1.52)).toBe(false)
         expect(isValidPlotCoord(76.5, 15.137)).toBe(false)
+    })
+})
+
+describe('formatSurveyLabel', () => {
+    it('formats survey with and without subdiv', () => {
+        expect(formatSurveyLabel({ survey: '1', subdiv: '2-A' })).toBe('1/2-A')
+        expect(formatSurveyLabel({ survey: '42', subdiv: '' })).toBe('42')
+    })
+})
+
+describe('sortSurveyOptionLabels', () => {
+    it('orders shorter survey numbers before longer prefix matches', () => {
+        const sorted = ['101/3', '1/1', '1/11'].sort(sortSurveyOptionLabels)
+        expect(sorted).toEqual(['1/1', '1/11', '101/3'])
     })
 })

--- a/js/tests/cadastral-search.test.js
+++ b/js/tests/cadastral-search.test.js
@@ -5,6 +5,7 @@ import {
     scoreSurveyMatch,
     villageEntryKey,
     parseVillageEntryKey,
+    isValidPlotCoord,
 } from '../cadastral-search.js'
 
 describe('parseSurveyQuery', () => {
@@ -94,5 +95,18 @@ describe('normalizeSurveySegment', () => {
     it('strips non-alphanumeric characters', () => {
         expect(normalizeSurveySegment('2-A')).toBe('2a')
         expect(normalizeSurveySegment('')).toBe('')
+    })
+})
+
+describe('isValidPlotCoord', () => {
+    it('accepts coordinates within Goa bounds', () => {
+        expect(isValidPlotCoord(73.964, 15.253)).toBe(true)
+    })
+
+    it('rejects null and out-of-state outliers', () => {
+        expect(isValidPlotCoord(null, 15.253)).toBe(false)
+        expect(isValidPlotCoord(73.964, null)).toBe(false)
+        expect(isValidPlotCoord(145.21, -1.52)).toBe(false)
+        expect(isValidPlotCoord(76.5, 15.137)).toBe(false)
     })
 })


### PR DESCRIPTION
## Summary

- Fixes village fly-to when selecting a village from the cadastral search dropdown (e.g. **Navelim — SALCETE** landing on Navelim, Divar instead)
- Scopes **`getVillageCenter()`**, **`queryCadastralPlotsByVillage()`**, and **`listSurveyOptionsForVillage()`** by **village + taluka**, not village name alone
- Computes village center as the mean of **valid** plot centroids for the selected village/taluka pair (not the first matching parquet row)
- Rejects null and out-of-Goa-bounds coordinates via `isValidPlotCoord()` so bad source data no longer skews fly-to or plot results
- Adds taluka-scoped `listSurveyOptionsForVillage()` so the mobile bottom-sheet survey picker (separate PR) can merge cleanly after this lands

Closes #243

## Root cause

Goa has multiple villages with the same name in different talukas (e.g. Navelim in Salcette, Tiswadi, and Bicholim). Cadastral queries matched on **village name only**, so selecting **Navelim — SALCETE** could:

- Fly to the wrong taluka’s first plot coordinate
- Return survey/plot results from other talukas (e.g. `1/1` matches from Tiswadi when Salcette surveys start at `10/1`)

Even after scoping by taluka, the **mean center calculation was wrong because some source coordinates are invalid**. A handful of bad plot centroids in the parquet file skew the average when included:

| Navelim, SALCETE | Value |
|---|---|
| Total plots | 3,728 |
| Invalid centroid rows | 12 (null or outside Goa bounds) |
| Center averaging **all** plots | (74.004, 15.256) |
| Center averaging **valid** plots only | (73.964, 15.254) |

Example bad rows: `null` coordinates; lon 145°, lat −1.5°; lon 130°, lat 28°; lon 81°, lat 13° — clearly not in Goa. Including even a few of these pulls the computed village center ~4 km off.

Statewide, the parquet has **~503 such rows** (~416 null + ~87 out of Goa bounds) out of ~828k plots (~0.06%). The fix filters these at query time via `isValidPlotCoord()` (Goa bounding box + finite check). Cleaning them at source in the [goa-cadastral-search](https://github.com/publicmap/goa-cadastral-search) data pipeline remains a follow-up.

## API changes

| Function | Before | After |
|----------|--------|-------|
| `getVillageCenter(villageName)` | First row matching village name | Mean of valid centroids for village + taluka |
| `queryCadastralPlotsByVillage(villageName, surveyRaw)` | Village name only | `(villageName, taluka, surveyRaw)` |
| `listSurveyOptionsForVillage(...)` | *(new)* | `(villageName, taluka, filterRaw, limit)` — taluka-scoped survey labels for mobile picker |

Free-text search (`Navelim 1/1` in the main box) still searches all matching village names, but each candidate is scoped to its own taluka.

## Test plan

- [ ] Open Goa atlas, focus search box, select **Navelim — SALCETE** from village dropdown → map flies to Margao area (~73.96, 15.25), not Divar/Tiswadi
- [ ] Select **Navelim — TISWADI** → flies to Divar island area
- [ ] With **Navelim — SALCETE** selected, search survey **`1/1`** → **no results** (Salcette surveys start at `10/1`)
- [ ] With **Navelim — SALCETE** selected, search survey **`10/1`** → Salcette plots only (labels show `— SALCETE`)
- [ ] With **Navelim — TISWADI** selected, search survey **`1/1`** → Tiswadi plots only
- [ ] `npm test -- js/tests/cadastral-search.test.js` passes