### PR TITLE
Mobile plot search bottom sheets for cadastral search

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -249,17 +249,20 @@
 
 .cadastral-picker-drawer {
     --size: 70vh;
+    --header-spacing: 0.75rem;
+    --body-spacing: 0.5rem 0.75rem 0.75rem;
     z-index: 10000;
 }
 
 .cadastral-picker-drawer::part(panel) {
     width: 100%;
     max-width: 100%;
-    max-height: 70vh;
     border-radius: 0.75rem 0.75rem 0 0;
+    border-right: 0;
     background: #111827;
     color: #f3f4f6;
     border-top: 1px solid #374151;
+    padding: 0;
 }
 
 .cadastral-picker-drawer::part(header) {
@@ -285,7 +288,6 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
-    padding: 0.5rem 0.75rem 0.75rem;
 }
 
 .cadastral-picker-body {
@@ -350,6 +352,10 @@
     }
 
     .cadastral-desktop-only {
+        display: none !important;
+    }
+
+    .cadastral-results {
         display: none !important;
     }
 
@@ -1663,19 +1669,19 @@ header h1 {
     opacity: 0.9;
 }
 
-sl-drawer {
+sl-drawer:not(.cadastral-picker-drawer) {
     --header-spacing: 5px;
     --body-spacing: 5px;
     color: white;
 }
 
-sl-drawer::part(overlay) {
+sl-drawer:not(.cadastral-picker-drawer)::part(overlay) {
     background: none;
     pointer-events: none;
     /* Prevent overlay from capturing clicks */
 }
 
-sl-drawer::part(panel) {
+sl-drawer:not(.cadastral-picker-drawer)::part(panel) {
     background: hsla(0, 0%, 35%, 0.902);
     backdrop-filter: blur(8px);
     border-right: 1px solid rgba(0, 0, 0, 0.1);
@@ -1684,7 +1690,7 @@ sl-drawer::part(panel) {
     padding: 5px 10px;
 }
 
-sl-drawer::part(close-button) {
+sl-drawer:not(.cadastral-picker-drawer)::part(close-button) {
     color: #fdfdfd;
     font-size: 1.5rem;
 }
@@ -2042,13 +2048,13 @@ sl-details::part(content) {
     padding: 0px;
 }
 
-sl-drawer sl-details::part(base) {
+sl-drawer:not(.cadastral-picker-drawer) sl-details::part(base) {
     padding: 0;
     border: 1px solid #535353;
     box-shadow: inset 0px 0px 3px rgb(69 69 69);
 }
 
-sl-drawer sl-details::part(content) {
+sl-drawer:not(.cadastral-picker-drawer) sl-details::part(content) {
     padding: 10px;
     box-shadow: inset 0px 0px 3px rgb(69 69 69);
     background-color: rgb(255, 251, 243);

--- a/css/styles.css
+++ b/css/styles.css
@@ -223,9 +223,144 @@
     line-height: 1.25;
 }
 
+.cadastral-field-trigger {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 36px;
+    padding: 0.375rem 0.75rem;
+    border: 1px solid #374151;
+    border-radius: 0.375rem;
+    background: #1f2937;
+    color: #9ca3af;
+    font-size: 0.875rem;
+    text-align: left;
+    cursor: pointer;
+}
+
+.cadastral-field-trigger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.cadastral-field-trigger__label--filled {
+    color: #f3f4f6;
+}
+
+.cadastral-picker-drawer {
+    --size: 70vh;
+    z-index: 10000;
+}
+
+.cadastral-picker-drawer::part(panel) {
+    width: 100%;
+    max-width: 100%;
+    max-height: 70vh;
+    border-radius: 0.75rem 0.75rem 0 0;
+    background: #111827;
+    color: #f3f4f6;
+    border-top: 1px solid #374151;
+}
+
+.cadastral-picker-drawer::part(header) {
+    border-bottom: 1px solid #374151;
+}
+
+.cadastral-picker-drawer::part(title) {
+    color: #f3f4f6;
+}
+
+.cadastral-picker-drawer::part(close-button) {
+    color: #f3f4f6;
+}
+
+.cadastral-picker-drawer::part(overlay) {
+    background: rgba(0, 0, 0, 0.5);
+    pointer-events: auto;
+}
+
+.cadastral-picker-drawer::part(body) {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    padding: 0.5rem 0.75rem 0.75rem;
+}
+
+.cadastral-picker-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.cadastral-picker-search {
+    flex-shrink: 0;
+}
+
+.cadastral-picker-search::part(base) {
+    background: #1f2937;
+    border-color: #374151;
+    color: #f3f4f6;
+}
+
+.cadastral-picker-list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 12rem;
+    -webkit-overflow-scrolling: touch;
+}
+
+.cadastral-picker-item {
+    display: block;
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    border: 0;
+    background: transparent;
+    color: #f3f4f6;
+    font-size: 0.875rem;
+    text-align: left;
+    cursor: pointer;
+}
+
+.cadastral-picker-item:hover,
+.cadastral-picker-item:focus {
+    background: #374151;
+    outline: none;
+}
+
+.cadastral-picker-hint {
+    padding: 1rem 0.75rem;
+    color: #9ca3af;
+    font-size: 0.875rem;
+    text-align: center;
+}
+
 @media (max-width: 768px) {
     #mapbox-search-box {
         max-width: 100%;
+    }
+
+    .cadastral-search-panel {
+        flex-direction: column;
+        gap: 0.375rem;
+    }
+
+    .cadastral-desktop-only {
+        display: none !important;
+    }
+
+    .cadastral-dropdown--picker-open .cadastral-results {
+        display: none !important;
+    }
+}
+
+@media (min-width: 769px) {
+    .cadastral-mobile-only {
+        display: none !important;
     }
 }
 

--- a/js/cadastral-search-ui.js
+++ b/js/cadastral-search-ui.js
@@ -4,7 +4,6 @@ import {
     getVillageCenter,
     getVillageList,
     isCadastralSearchEnabled,
-    listSurveyOptionsForVillage,
     parseVillageEntryKey,
     queryCadastralPlotsByVillage,
     villageEntryKey,
@@ -26,6 +25,7 @@ export class CadastralSearchUI {
         this._villageList = []
         this._pickerMode = null
         this._pickerTrigger = null
+        this._pendingPickerSurvey = null
         this._mobileMq = window.matchMedia(MOBILE_BREAKPOINT)
 
         this._buildDOM()
@@ -83,9 +83,9 @@ export class CadastralSearchUI {
 
         this.pickerDrawer = document.createElement('sl-drawer')
         this.pickerDrawer.id = 'cadastral-picker-drawer'
-        this.pickerDrawer.className = 'cadastral-picker-drawer'
-        this.pickerDrawer.setAttribute('placement', 'bottom')
-        this.pickerDrawer.setAttribute('label', 'Select')
+        this.pickerDrawer.className = 'cadastral-picker-drawer drawer-placement-bottom'
+        this.pickerDrawer.placement = 'bottom'
+        this.pickerDrawer.label = 'Select'
         this.pickerDrawer.innerHTML = `
             <div class="cadastral-picker-body">
                 <sl-input id="cadastral-picker-search" class="cadastral-picker-search"
@@ -128,6 +128,10 @@ export class CadastralSearchUI {
             this._syncVillageFromMap()
         }
         this._syncTriggerLabels()
+    }
+
+    _isPickerOpen() {
+        return Boolean(this.pickerDrawer?.open)
     }
 
     _setupMobilePicker() {
@@ -222,7 +226,7 @@ export class CadastralSearchUI {
         this.dropdown?.classList.add('cadastral-dropdown--picker-open')
 
         const title = mode === 'village' ? 'Select village' : 'Select survey number'
-        this.pickerDrawer.setAttribute('label', title)
+        this.pickerDrawer.label = title
 
         const placeholder = mode === 'village' ? 'Search villages' : 'Type to search survey numbers'
         this.pickerSearch.placeholder = placeholder
@@ -290,16 +294,54 @@ export class CadastralSearchUI {
             return
         }
 
-        listSurveyOptionsForVillage(this.selectedVillage.village, query)
-            .then(labels => {
+        this._pendingPickerSurvey = query
+        queryCadastralPlotsByVillage(this.selectedVillage.village, query, 50)
+            .then(features => {
                 if (this._pickerMode !== 'survey') return
-                const items = labels.map(label => ({ label, value: label }))
-                this._renderPickerList(items, ({ value }) => {
-                    this._selectSurvey(value)
-                    this._closePicker()
-                })
+                if (this._pendingPickerSurvey !== query) return
+                this._renderPickerPlotResults(features)
             })
             .catch(err => console.error('[cadastral-ui]', err))
+    }
+
+    _renderPickerPlotResults(features) {
+        if (!features.length) {
+            this.pickerList.innerHTML = `
+                <div class="cadastral-picker-hint">No matches found</div>
+            `
+            return
+        }
+
+        this.pickerList.innerHTML = features.map((feature, index) => `
+            <button type="button" class="cadastral-result cadastral-picker-plot-result" role="option"
+                data-index="${index}" tabindex="-1">
+                <span class="cadastral-result__icon" aria-hidden="true">📍</span>
+                <span class="cadastral-result__text">${this.searchControl._escapeHtml(feature.properties.name)}</span>
+            </button>
+        `).join('')
+
+        this.pickerList.querySelectorAll('.cadastral-picker-plot-result').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const index = Number(btn.dataset.index)
+                const feature = features[index]
+                if (feature) this._selectPlotResult(feature)
+            })
+        })
+    }
+
+    _selectPlotResult(feature) {
+        const surveyRaw = feature.properties._surveyRaw || ''
+        if (surveyRaw) {
+            this.surveyInput.value = surveyRaw
+            this._syncTriggerLabels()
+        }
+        this._clearResults()
+        this._closePicker()
+        this._hide()
+        this.searchControl.handleRetrieve(new CustomEvent('retrieve', {
+            detail: { features: [feature] },
+        }))
+        this.searchControl.suppressSuggestions()
     }
 
     _selectVillage(entry) {
@@ -310,12 +352,6 @@ export class CadastralSearchUI {
         sessionStorage.setItem('cadastral-village', key)
         this._syncTriggerLabels()
         this._flyToVillage(this.selectedVillage?.village)
-        this._runSearch()
-    }
-
-    _selectSurvey(value) {
-        this.surveyInput.value = value
-        this._syncTriggerLabels()
         this._runSearch()
     }
 
@@ -403,7 +439,7 @@ export class CadastralSearchUI {
         const active = document.activeElement
         if (!active || !this.dropdown) return false
         if (this.dropdown.contains(active)) return true
-        if (this.pickerDrawer?.open && this.pickerDrawer.contains(active)) return true
+        if (this._isPickerOpen() && this.pickerDrawer.contains(active)) return true
         const host = active.getRootNode?.()?.host
         return Boolean(host && (this.dropdown.contains(host) || this.pickerDrawer?.contains(host)))
     }
@@ -551,7 +587,10 @@ export class CadastralSearchUI {
             return
         }
 
-        if (this._isMobileLayout() && this.pickerDrawer?.open) {
+        if (this._isMobileLayout()) {
+            if (this._isPickerOpen() && this._pickerMode === 'survey') {
+                this._renderPickerPlotResults(features)
+            }
             return
         }
 

--- a/js/cadastral-search-ui.js
+++ b/js/cadastral-search-ui.js
@@ -1,12 +1,16 @@
 import {
     detectVillageFromMapCenter,
+    filterVillageList,
     getVillageCenter,
     getVillageList,
     isCadastralSearchEnabled,
+    listSurveyOptionsForVillage,
     parseVillageEntryKey,
     queryCadastralPlotsByVillage,
     villageEntryKey,
 } from './cadastral-search.js'
+
+const MOBILE_BREAKPOINT = '(max-width: 768px)'
 
 export class CadastralSearchUI {
     constructor(map, searchControl) {
@@ -16,17 +20,27 @@ export class CadastralSearchUI {
         this.selectedVillage = null
         this.userPickedVillage = false
         this._debounceTimer = null
+        this._pickerDebounceTimer = null
         this._pendingSurvey = null
         this._blurTimer = null
+        this._villageList = []
+        this._pickerMode = null
+        this._pickerTrigger = null
+        this._mobileMq = window.matchMedia(MOBILE_BREAKPOINT)
 
         this._buildDOM()
         this._bindEvents()
+        this._setupMobilePicker()
         this._hookMapboxSearchFocus()
         this._loadVillages()
     }
 
     isActive() {
         return this.visible
+    }
+
+    _isMobileLayout() {
+        return this._mobileMq.matches
     }
 
     _buildDOM() {
@@ -38,10 +52,24 @@ export class CadastralSearchUI {
         this.panel = document.createElement('div')
         this.panel.className = 'cadastral-search-panel hidden'
         this.panel.innerHTML = `
-            <sl-select id="cadastral-village-select" class="cadastral-village-select"
+            <sl-select id="cadastral-village-select"
+                class="cadastral-village-select cadastral-desktop-only"
                 placeholder="Village" hoist clearable size="small"></sl-select>
-            <sl-input id="cadastral-survey-input" class="cadastral-survey-input"
+            <sl-input id="cadastral-survey-input"
+                class="cadastral-survey-input cadastral-desktop-only"
                 placeholder="Survey no." clearable size="small"></sl-input>
+            <button type="button" id="cadastral-village-trigger"
+                class="cadastral-village-trigger cadastral-mobile-only cadastral-field-trigger"
+                role="combobox" aria-haspopup="dialog" aria-expanded="false"
+                aria-label="Select village">
+                <span class="cadastral-field-trigger__label">Village</span>
+            </button>
+            <button type="button" id="cadastral-survey-trigger"
+                class="cadastral-survey-trigger cadastral-mobile-only cadastral-field-trigger"
+                role="combobox" aria-haspopup="dialog" aria-expanded="false"
+                aria-label="Select survey number" aria-disabled="true" disabled>
+                <span class="cadastral-field-trigger__label">Survey no.</span>
+            </button>
         `
 
         this.resultsEl = document.createElement('div')
@@ -53,19 +81,38 @@ export class CadastralSearchUI {
         this.dropdown.appendChild(this.panel)
         this.dropdown.appendChild(this.resultsEl)
 
+        this.pickerDrawer = document.createElement('sl-drawer')
+        this.pickerDrawer.id = 'cadastral-picker-drawer'
+        this.pickerDrawer.className = 'cadastral-picker-drawer'
+        this.pickerDrawer.setAttribute('placement', 'bottom')
+        this.pickerDrawer.setAttribute('label', 'Select')
+        this.pickerDrawer.innerHTML = `
+            <div class="cadastral-picker-body">
+                <sl-input id="cadastral-picker-search" class="cadastral-picker-search"
+                    placeholder="Search" clearable size="small"></sl-input>
+                <div id="cadastral-picker-list" class="cadastral-picker-list"
+                    role="listbox"></div>
+            </div>
+        `
+
         document.body.appendChild(this.dropdown)
+        document.body.appendChild(this.pickerDrawer)
 
         this.villageSelect = this.panel.querySelector('#cadastral-village-select')
         this.surveyInput = this.panel.querySelector('#cadastral-survey-input')
+        this.villageTrigger = this.panel.querySelector('#cadastral-village-trigger')
+        this.surveyTrigger = this.panel.querySelector('#cadastral-survey-trigger')
+        this.pickerSearch = this.pickerDrawer.querySelector('#cadastral-picker-search')
+        this.pickerList = this.pickerDrawer.querySelector('#cadastral-picker-list')
     }
 
     async _loadVillages() {
         if (!this.villageSelect) return
 
-        const villages = await getVillageList()
+        this._villageList = await getVillageList()
         const fragment = document.createDocumentFragment()
 
-        villages
+        this._villageList
             .slice()
             .sort((a, b) => a.village.localeCompare(b.village))
             .forEach(entry => {
@@ -80,13 +127,205 @@ export class CadastralSearchUI {
         if (this.visible && !this.userPickedVillage && !this.selectedVillage) {
             this._syncVillageFromMap()
         }
+        this._syncTriggerLabels()
+    }
+
+    _setupMobilePicker() {
+        this.pickerDrawer.addEventListener('sl-after-show', () => {
+            this._refreshPickerList()
+        })
+
+        this.pickerDrawer.addEventListener('sl-hide', () => {
+            const active = document.activeElement
+            if (active && this.pickerDrawer.contains(active)) active.blur()
+            if (this._pickerTrigger) {
+                this._pickerTrigger.setAttribute('aria-expanded', 'false')
+            }
+            this.dropdown?.classList.remove('cadastral-dropdown--picker-open')
+            this._pickerMode = null
+            this._pickerTrigger = null
+            if (this._isMobileLayout() && this._getSurveyRaw()) {
+                this._runSearch()
+            }
+        })
+
+        this._mobileMq.addEventListener('change', () => {
+            if (!this._isMobileLayout()) this._closePicker()
+            this._syncTriggerLabels()
+        })
+
+        this._attachPickerSearchListeners()
+    }
+
+    _attachPickerSearchListeners() {
+        if (this.pickerDrawer._pickerInputHooked) return
+        this.pickerDrawer._pickerInputHooked = true
+
+        const onPickerInput = () => {
+            clearTimeout(this._pickerDebounceTimer)
+            this._pickerDebounceTimer = setTimeout(() => this._refreshPickerList(), 200)
+        }
+
+        this.pickerSearch?.addEventListener('sl-input', onPickerInput)
+        this.pickerSearch?.addEventListener('sl-change', onPickerInput)
+        this.pickerDrawer.addEventListener('input', (event) => {
+            if (event.composedPath().includes(this.pickerSearch)) onPickerInput()
+        }, true)
+    }
+
+    _refreshPickerList() {
+        const query = this.pickerSearch?.value ?? ''
+        if (this._pickerMode === 'village') {
+            this._updateVillagePicker(query)
+        } else if (this._pickerMode === 'survey') {
+            this._updateSurveyPicker(query)
+        }
+    }
+
+    _syncTriggerLabels() {
+        if (!this.villageTrigger || !this.surveyTrigger) return
+
+        const villageLabel = this.villageTrigger.querySelector('.cadastral-field-trigger__label')
+        const surveyLabel = this.surveyTrigger.querySelector('.cadastral-field-trigger__label')
+
+        if (this.selectedVillage) {
+            villageLabel.textContent = `${this.selectedVillage.village} — ${this.selectedVillage.taluka}`
+            villageLabel.classList.add('cadastral-field-trigger__label--filled')
+        } else {
+            villageLabel.textContent = 'Village'
+            villageLabel.classList.remove('cadastral-field-trigger__label--filled')
+        }
+
+        const surveyRaw = this._getSurveyRaw()
+        if (surveyRaw) {
+            surveyLabel.textContent = surveyRaw
+            surveyLabel.classList.add('cadastral-field-trigger__label--filled')
+        } else {
+            surveyLabel.textContent = 'Survey no.'
+            surveyLabel.classList.remove('cadastral-field-trigger__label--filled')
+        }
+
+        const hasVillage = Boolean(this.selectedVillage?.village)
+        this.surveyTrigger.disabled = !hasVillage
+        this.surveyTrigger.setAttribute('aria-disabled', hasVillage ? 'false' : 'true')
+    }
+
+    _openPicker(mode) {
+        if (!this._isMobileLayout()) return
+        if (mode === 'survey' && !this.selectedVillage?.village) return
+
+        this._pickerMode = mode
+        this._pickerTrigger = mode === 'village' ? this.villageTrigger : this.surveyTrigger
+        this._pickerTrigger.setAttribute('aria-expanded', 'true')
+
+        this._clearResults()
+        this.dropdown?.classList.add('cadastral-dropdown--picker-open')
+
+        const title = mode === 'village' ? 'Select village' : 'Select survey number'
+        this.pickerDrawer.setAttribute('label', title)
+
+        const placeholder = mode === 'village' ? 'Search villages' : 'Type to search survey numbers'
+        this.pickerSearch.placeholder = placeholder
+        this.pickerSearch.value = mode === 'survey' ? this._getSurveyRaw() : ''
+
+        this._renderPickerPlaceholder(mode)
+        this.pickerDrawer.show()
+
+        requestAnimationFrame(() => {
+            const input = this.pickerSearch.shadowRoot?.querySelector('input')
+            input?.focus?.()
+            this._refreshPickerList()
+        })
+    }
+
+    _closePicker() {
+        if (this.pickerDrawer.open) this.pickerDrawer.hide()
+    }
+
+    _renderPickerPlaceholder(mode) {
+        const message = mode === 'village'
+            ? 'Type to filter villages'
+            : 'Type to search survey numbers'
+        this.pickerList.innerHTML = `
+            <div class="cadastral-picker-hint">${message}</div>
+        `
+    }
+
+    _renderPickerList(items, onSelect) {
+        if (!items.length) {
+            this.pickerList.innerHTML = `
+                <div class="cadastral-picker-hint">No matches found</div>
+            `
+            return
+        }
+
+        this.pickerList.innerHTML = items.map((item, index) => `
+            <button type="button" class="cadastral-picker-item" role="option"
+                data-index="${index}" tabindex="-1">${this.searchControl._escapeHtml(item.label)}</button>
+        `).join('')
+
+        this.pickerList.querySelectorAll('.cadastral-picker-item').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const index = Number(btn.dataset.index)
+                onSelect(items[index])
+            })
+        })
+    }
+
+    _updateVillagePicker(query) {
+        const matches = filterVillageList(this._villageList, query)
+        const items = matches.map(entry => ({
+            label: `${entry.village} — ${entry.taluka}`,
+            entry,
+        }))
+        this._renderPickerList(items, ({ entry }) => {
+            this._selectVillage(entry)
+            this._closePicker()
+        })
+    }
+
+    _updateSurveyPicker(query) {
+        if (!query.trim()) {
+            this._renderPickerPlaceholder('survey')
+            return
+        }
+
+        listSurveyOptionsForVillage(this.selectedVillage.village, query)
+            .then(labels => {
+                if (this._pickerMode !== 'survey') return
+                const items = labels.map(label => ({ label, value: label }))
+                this._renderPickerList(items, ({ value }) => {
+                    this._selectSurvey(value)
+                    this._closePicker()
+                })
+            })
+            .catch(err => console.error('[cadastral-ui]', err))
+    }
+
+    _selectVillage(entry) {
+        this.userPickedVillage = true
+        this.selectedVillage = entry
+        const key = villageEntryKey(entry)
+        this.villageSelect.value = key
+        sessionStorage.setItem('cadastral-village', key)
+        this._syncTriggerLabels()
+        this._flyToVillage(this.selectedVillage?.village)
+        this._runSearch()
+    }
+
+    _selectSurvey(value) {
+        this.surveyInput.value = value
+        this._syncTriggerLabels()
+        this._runSearch()
     }
 
     _bindEvents() {
         if (!this.dropdown) return
 
         this.dropdown.addEventListener('mousedown', e => {
-            const interactive = e.target.closest('sl-input, sl-select, input, button, [tabindex]')
+            const interactive = e.target.closest(
+                'sl-input, sl-select, input, button, [tabindex], .cadastral-field-trigger',
+            )
             if (!interactive) e.preventDefault()
         })
         this.dropdown.addEventListener('focusin', () => {
@@ -107,6 +346,7 @@ export class CadastralSearchUI {
             this.userPickedVillage = true
             this.selectedVillage = parseVillageEntryKey(this.villageSelect.value)
             sessionStorage.setItem('cadastral-village', this.villageSelect.value)
+            this._syncTriggerLabels()
             this._flyToVillage(this.selectedVillage?.village)
             this._runSearch()
         })
@@ -115,10 +355,12 @@ export class CadastralSearchUI {
             this.selectedVillage = null
             this.userPickedVillage = true
             sessionStorage.removeItem('cadastral-village')
+            this._syncTriggerLabels()
             this._clearResults()
         })
 
         this.surveyInput?.addEventListener('sl-input', () => {
+            this._syncTriggerLabels()
             clearTimeout(this._debounceTimer)
             this._debounceTimer = setTimeout(() => this._runSearch(), 250)
         })
@@ -128,6 +370,19 @@ export class CadastralSearchUI {
                 event.preventDefault()
                 this._selectFirstResult()
             }
+        })
+
+        this.villageTrigger?.addEventListener('click', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            this._openPicker('village')
+        })
+
+        this.surveyTrigger?.addEventListener('click', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            if (!this.selectedVillage?.village) return
+            this._openPicker('survey')
         })
 
         this.map.on('moveend', () => {
@@ -147,7 +402,10 @@ export class CadastralSearchUI {
     _dropdownHasFocus() {
         const active = document.activeElement
         if (!active || !this.dropdown) return false
-        return this.dropdown.contains(active)
+        if (this.dropdown.contains(active)) return true
+        if (this.pickerDrawer?.open && this.pickerDrawer.contains(active)) return true
+        const host = active.getRootNode?.()?.host
+        return Boolean(host && (this.dropdown.contains(host) || this.pickerDrawer?.contains(host)))
     }
 
     _positionDropdown() {
@@ -221,7 +479,10 @@ export class CadastralSearchUI {
         this.dropdown.classList.remove('hidden')
         this.panel.classList.remove('hidden')
 
-        if (this.userPickedVillage) return
+        if (this.userPickedVillage) {
+            this._syncTriggerLabels()
+            return
+        }
 
         const saved = sessionStorage.getItem('cadastral-village')
         if (saved && !this.selectedVillage) {
@@ -230,10 +491,12 @@ export class CadastralSearchUI {
         } else {
             this._syncVillageFromMap()
         }
+        this._syncTriggerLabels()
     }
 
     _hide() {
         this.visible = false
+        this._closePicker()
         this.panel.classList.add('hidden')
         this._clearResults()
         this.dropdown.classList.add('hidden')
@@ -245,6 +508,7 @@ export class CadastralSearchUI {
 
         this.selectedVillage = entry
         this.villageSelect.value = villageEntryKey(entry)
+        this._syncTriggerLabels()
     }
 
     _flyToVillage(villageName) {
@@ -284,6 +548,10 @@ export class CadastralSearchUI {
     _renderResults(features) {
         if (!features.length) {
             this._clearResults()
+            return
+        }
+
+        if (this._isMobileLayout() && this.pickerDrawer?.open) {
             return
         }
 

--- a/js/cadastral-search.js
+++ b/js/cadastral-search.js
@@ -56,12 +56,21 @@ function lazyInit() {
     return initPromise
 }
 
-function findMatchingVillages(typedVillage) {
-    const q = typedVillage.toLowerCase()
+export function filterVillageList(villages, typedVillage) {
+    const q = typedVillage.trim().toLowerCase()
+    const sorted = villages.slice().sort((a, b) => a.village.localeCompare(b.village))
+    if (!q) return sorted
+
     const threshold = q.length <= 4 ? 1 : 2
-    const prefixMatches = villageList.filter(v => v.village.toLowerCase().startsWith(q))
-    if (prefixMatches.length) return prefixMatches
-    return villageList.filter(v => levenshtein.get(v.village.toLowerCase(), q) <= threshold)
+    const prefixMatches = villages.filter(v => v.village.toLowerCase().startsWith(q))
+    const matches = prefixMatches.length
+        ? prefixMatches
+        : villages.filter(v => levenshtein.get(v.village.toLowerCase(), q) <= threshold)
+    return matches.sort((a, b) => a.village.localeCompare(b.village))
+}
+
+function findMatchingVillages(typedVillage) {
+    return filterVillageList(villageList, typedVillage)
 }
 
 function decodeStatValue(val) {
@@ -109,6 +118,23 @@ export function parseCadastralQuery(query) {
 export function formatCadastralLabel({ village, taluka, survey, subdiv }) {
     const surveyPart = subdiv ? `Survey ${survey}/${subdiv}` : `Survey ${survey}`
     return `${village} — ${surveyPart} — ${taluka}`
+}
+
+export function formatSurveyLabel({ survey, subdiv }) {
+    return subdiv ? `${survey}/${subdiv}` : String(survey ?? '')
+}
+
+function labelToSurveyRow(label) {
+    const slashIdx = label.indexOf('/')
+    if (slashIdx === -1) return { survey: label, subdiv: '' }
+    return { survey: label.slice(0, slashIdx), subdiv: label.slice(slashIdx + 1) }
+}
+
+export function sortSurveyOptionLabels(a, b) {
+    return sortSurveyMatches(
+        { row: labelToSurveyRow(a), score: 0 },
+        { row: labelToSurveyRow(b), score: 0 },
+    )
 }
 
 export function normalizeSurveySegment(str) {
@@ -313,6 +339,41 @@ export async function queryCadastralPlotsByVillage(villageName, surveyRaw, limit
     const matches = await collectMatchesForVillage(villageName, parsed)
     matches.sort(sortSurveyMatches)
     return matches.slice(0, limit).map(({ row }) => rowToFeature(row))
+}
+
+export async function listSurveyOptionsForVillage(villageName, filterRaw = '', limit = 100) {
+    if (!isCadastralSearchEnabled() || !villageName) return []
+    await lazyInit()
+
+    const parsed = parseSurveyQuery(filterRaw)
+    if (!parsed.surveyPrefix) return []
+
+    const seen = new Set()
+    const labels = []
+    const candidateLower = villageName.toLowerCase()
+    const ranges = getMatchingRowGroupRanges(villageName)
+
+    for (const range of ranges) {
+        const rows = await parquetReadObjects({
+            file: parquetFile,
+            compressors,
+            columns: ['village', 'survey', 'subdiv'],
+            rowStart: range.start,
+            rowEnd: range.end,
+        })
+
+        for (const row of rows) {
+            if (row.village.toLowerCase() !== candidateLower) continue
+            if (scoreSurveyMatch(row, parsed) === null) continue
+            const label = formatSurveyLabel(row)
+            if (!label || seen.has(label)) continue
+            seen.add(label)
+            labels.push(label)
+        }
+    }
+
+    labels.sort(sortSurveyOptionLabels)
+    return labels.slice(0, limit)
 }
 
 export async function queryCadastralPlots(villagePart, surveyRaw, limit = 5) {

--- a/js/cadastral-search.js
+++ b/js/cadastral-search.js
@@ -205,6 +205,7 @@ function rowToFeature(r) {
             place_name: formatCadastralLabel(r),
             place_type: ['cadastral', 'plot'],
             text: formatCadastralLabel(r),
+            _surveyRaw: formatSurveyLabel(r),
             _isLocalSuggestion: true,
             _isCadastralParquet: true,
         },

--- a/js/tests/cadastral-search.test.js
+++ b/js/tests/cadastral-search.test.js
@@ -5,6 +5,9 @@ import {
     scoreSurveyMatch,
     villageEntryKey,
     parseVillageEntryKey,
+    formatSurveyLabel,
+    sortSurveyOptionLabels,
+    filterVillageList,
 } from '../cadastral-search.js'
 
 describe('parseSurveyQuery', () => {
@@ -94,5 +97,49 @@ describe('normalizeSurveySegment', () => {
     it('strips non-alphanumeric characters', () => {
         expect(normalizeSurveySegment('2-A')).toBe('2a')
         expect(normalizeSurveySegment('')).toBe('')
+    })
+})
+
+describe('formatSurveyLabel', () => {
+    it('formats survey with and without subdiv', () => {
+        expect(formatSurveyLabel({ survey: '1', subdiv: '2-A' })).toBe('1/2-A')
+        expect(formatSurveyLabel({ survey: '42', subdiv: '' })).toBe('42')
+    })
+})
+
+describe('sortSurveyOptionLabels', () => {
+    it('orders shorter survey numbers before longer prefix matches', () => {
+        const sorted = ['101/3', '1/1', '1/11'].sort(sortSurveyOptionLabels)
+        expect(sorted).toEqual(['1/1', '1/11', '101/3'])
+    })
+})
+
+describe('filterVillageList', () => {
+    const villages = [
+        { village: 'Verlem', taluka: 'SANGUEM' },
+        { village: 'Verna', taluka: 'SALCETE' },
+        { village: 'Panaji', taluka: 'TISWADI' },
+    ]
+
+    it('returns all villages sorted when query is empty', () => {
+        expect(filterVillageList(villages, '')).toEqual([
+            { village: 'Panaji', taluka: 'TISWADI' },
+            { village: 'Verlem', taluka: 'SANGUEM' },
+            { village: 'Verna', taluka: 'SALCETE' },
+        ])
+    })
+
+    it('filters by prefix', () => {
+        expect(filterVillageList(villages, 'Ver')).toEqual([
+            { village: 'Verlem', taluka: 'SANGUEM' },
+            { village: 'Verna', taluka: 'SALCETE' },
+        ])
+    })
+
+    it('tolerates typos via levenshtein', () => {
+        expect(filterVillageList(villages, 'verlam')).toEqual([
+            { village: 'Verlem', taluka: 'SANGUEM' },
+            { village: 'Verna', taluka: 'SALCETE' },
+        ])
     })
 })


### PR DESCRIPTION
## Summary

- Adds a mobile-optimised cadastral plot search UI (≤768px): village and survey fields stack vertically and open full-width Shoelace bottom sheets for selection.
- Village picker filters the preloaded village list; survey picker queries parquet plot matches and shows the same 📍 plot results as desktop.
- Scopes global `sl-drawer` side-panel styles so the cadastral picker uses `placement="bottom"` and slides up from the bottom correctly; hides the dropdown `.cadastral-results` list on mobile.

## Changes

**UI (`js/cadastral-search-ui.js`)**
- Mobile trigger buttons replace inline `sl-select` / `sl-input` on small screens.
- `sl-drawer` bottom sheet for village search + filterable list and survey plot search.
- Plot selection from the sheet flies to the map (same behaviour as desktop result click).

**Search helpers (`js/cadastral-search.js`)**
- `filterVillageList`, `formatSurveyLabel`, `sortSurveyOptionLabels`, `listSurveyOptionsForVillage` for picker/filter logic.
- `_surveyRaw` on plot features for updating the survey trigger label after selection.

**Styles (`css/styles.css`)**
- Cadastral field triggers, picker drawer, and mobile layout rules.
- `sl-drawer:not(.cadastral-picker-drawer)` so map-control drawer styles do not affect the bottom sheet.

**Tests (`js/tests/cadastral-search.test.js`)**
- Unit tests for village filter and survey label helpers.

## Test plan

- [ ] Open `?atlas=goa` on a viewport ≤768px (or device emulation).
- [ ] Tap the search box → village/survey triggers appear stacked vertically.
- [ ] Tap **Village** → bottom sheet slides up from the bottom with searchable village list; select a village and confirm the trigger updates.
- [ ] Tap **Survey no.** → bottom sheet opens; type a survey (e.g. `10/1`) → plot results with 📍 appear in the sheet (not in the dropdown above).
- [ ] Select a plot → map flies to the plot, sheet closes, survey trigger shows the survey number.
- [ ] On desktop (>768px), confirm original inline `sl-select` + `sl-input` + dropdown results still work unchanged.
- [ ] `npm test -- cadastral-search`


Made with [Cursor](https://cursor.com)